### PR TITLE
Fixing the missing meta and props fields

### DIFF
--- a/src/route/compiler.js
+++ b/src/route/compiler.js
@@ -19,6 +19,8 @@ export class Compiler {
       children: children.map((child) => child._compile(true)),
       name: children.length ? undefined : this._compileName(),
       alias: children.length ? undefined : this._route._alias,
+      meta: children.length ? undefined : this._route._meta,
+      props: children.length ? undefined : this._route._props,
     }
 
     this._components(compiled)

--- a/src/route/route.js
+++ b/src/route/route.js
@@ -45,11 +45,11 @@ export class Route {
   }
 
   meta(key, value) {
-    return this._setObject(this.meta, 'meta', key, value)
+    return this._setObject(this._meta, 'meta', key, value)
   }
 
   props(key, value) {
-    return this._setObject(this.props, 'props', key, value)
+    return this._setObject(this._props, 'props', key, value)
   }
 
   prop(key, value) {


### PR DESCRIPTION
I don't know if it's right way to do but I realize that meta and props fields are misspelled and not getting recognized by vue-router because of the compiled result missing fields.